### PR TITLE
Fix import error

### DIFF
--- a/colab_demo.ipynb
+++ b/colab_demo.ipynb
@@ -359,6 +359,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# There are import errors under keras == 2.2.5\n",
+    "!pip install keras==2.2.4"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 3,
    "metadata": {
     "colab": {


### PR DESCRIPTION
There are some API changes in Keras 2.2.5 that causes import errors. We fix this error by installing Keras 2.2.4.